### PR TITLE
Remove null values and write empty outcode files

### DIFF
--- a/cdk/queries/uprn-to-ballots-first-letter.sql
+++ b/cdk/queries/uprn-to-ballots-first-letter.sql
@@ -1,39 +1,42 @@
-UNLOAD
-(
-SELECT combined_results.uprn,
-       combined_results.address,
-       combined_results.postcode,
-       array_sort(array_agg(DISTINCT combined_results.election_id)) AS ballot_ids,
-       combined_results.first_letter AS first_letter
-    FROM (SELECT ab.uprn,
-                 ab.address,
-                 ab.postcode,
-                 ab.first_letter,
-                 cb.election_id
-              FROM $from_table cb
-                       CROSS JOIN addressbase_partitioned ab
-              WHERE ST_CONTAINS(
-                      ST_Polygon(cb.geometry),
-                      ST_POINT(ab.longitude, ab.latitude)
-                    )
-                AND cb.source_table = 'Organisation'
-                AND ab.first_letter = '{first_letter}'
-          UNION
-          SELECT ab.uprn,
-                 ab.address,
-                 ab.postcode,
-                 ab.first_letter,
-                 cb.election_id
-              FROM $from_table cb
-                       CROSS JOIN addressbase_partitioned ab
-              WHERE ST_CONTAINS(
-                      ST_Polygon(cb.geometry),
-                      ST_POINT(ab.longitude, ab.latitude)
-                    )
-                AND cb.source_table = 'Division'
-                AND ab.first_letter = '{first_letter}') AS combined_results
-    GROUP BY combined_results.uprn, combined_results.address, combined_results.postcode, combined_results.first_letter )
-TO '$table_full_s3_path'
-WITH (
-    format = 'PARQUET', compression = 'SNAPPY', partitioned_by = ARRAY['first_letter']
-    )
+UNLOAD (
+		SELECT combined_results.uprn,
+			combined_results.address,
+			combined_results.postcode,
+			array_sort(array_agg(DISTINCT combined_results.election_id)) AS ballot_ids,
+			combined_results.first_letter AS first_letter
+		FROM (
+				SELECT ab.uprn,
+					ab.address,
+					ab.postcode,
+					ab.first_letter,
+					cb.election_id
+				FROM addressbase_partitioned ab
+					LEFT JOIN current_ballots cb ON ST_CONTAINS(
+						ST_Polygon(cb.geometry),
+						ST_POINT(ab.longitude, ab.latitude)
+					)
+					AND cb.source_table = 'Organisation'
+				WHERE ab.first_letter = '{first_letter}'
+				UNION
+				SELECT ab.uprn,
+					ab.address,
+					ab.postcode,
+					ab.first_letter,
+					cb.election_id
+				FROM addressbase_partitioned ab
+					LEFT JOIN current_ballots cb ON ST_CONTAINS(
+						ST_Polygon(cb.geometry),
+						ST_POINT(ab.longitude, ab.latitude)
+					)
+					AND cb.source_table = 'Division'
+				WHERE ab.first_letter = '{first_letter}'
+			) AS combined_results
+		GROUP BY combined_results.uprn,
+			combined_results.address,
+			combined_results.postcode,
+			combined_results.first_letter
+	) TO 's3://dc-data-baker-results-bucket/current_ballots_joined_to_address_base/' WITH (
+		format = 'PARQUET',
+		compression = 'SNAPPY',
+		partitioned_by = ARRAY [ 'first_letter' ]
+	)

--- a/cdk/queries/uprn-to-ballots-first-letter.sql
+++ b/cdk/queries/uprn-to-ballots-first-letter.sql
@@ -2,7 +2,7 @@ UNLOAD (
 		SELECT combined_results.uprn,
 			combined_results.address,
 			combined_results.postcode,
-			array_sort(array_agg(DISTINCT combined_results.election_id)) AS ballot_ids,
+			array_sort(filter(array_agg(DISTINCT combined_results.election_id), x -> x IS NOT NULL)) AS ballot_ids,
 			combined_results.first_letter AS first_letter
 		FROM (
 				SELECT ab.uprn,


### PR DESCRIPTION
This fixes a couple of bugs:

1. It remove null values from the list of ballot IDs
2. It writes an empty file per outcode, if none of the UPRNs in that outcode has a ballot.

I also changed the way we're reading the raw parquet files to make looping over a large first letter much faster. This requires more memory, but uses less CPU, so the Lambda maths works out well (e.g use more memory but execute for less time) 