### PR TITLE
Check for other instances of this step function before running

### DIFF
--- a/cdk/shared_components/lambdas/check_step_function_running.py
+++ b/cdk/shared_components/lambdas/check_step_function_running.py
@@ -1,0 +1,30 @@
+import boto3
+
+
+def handler(event, context):
+    state_machine_arn = event["stateMachineArn"]
+    current_execution_arn = event["currentExecutionArn"]
+
+    client = boto3.client("stepfunctions")
+
+    # List all running executions for the given state machine
+    response = client.list_executions(
+        stateMachineArn=state_machine_arn, statusFilter="RUNNING"
+    )
+    executions = response.get("executions", [])
+
+    # Filter out the current execution
+    other_executions = [
+        exe
+        for exe in executions
+        if exe["executionArn"] != current_execution_arn
+    ]
+
+    if other_executions:
+        # Another execution is running
+        return {
+            "proceed": False,
+            "message": "Another execution is already running",
+        }
+    # Safe to proceed
+    return {"proceed": True, "message": "No other executions running"}

--- a/cdk/shared_components/lambdas/check_step_function_running.py
+++ b/cdk/shared_components/lambdas/check_step_function_running.py
@@ -12,6 +12,10 @@ def handler(event, context):
         stateMachineArn=state_machine_arn, statusFilter="RUNNING"
     )
     executions = response.get("executions", [])
+    while next_token := response.get("nextToken"):
+        response = client.list_executions(stateMachineArn=state_machine_arn, statusFilter="RUNNING", next_token=next_token)
+        executions += response.get("executions", [])
+
 
     # Filter out the current execution
     other_executions = [

--- a/cdk/stacks/data_baker_core.py
+++ b/cdk/stacks/data_baker_core.py
@@ -89,6 +89,29 @@ class DataBakerCoreStack(DataBakerStack):
             )
         )
 
+
+        check_step_function_running_function = aws_lambda_python.PythonFunction(
+            self,
+            "check_step_function_running",
+            function_name="check_step_function_running",
+            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            handler="handler",
+            entry="cdk/shared_components/lambdas/",
+            index="check_step_function_running.py",
+            timeout=Duration.seconds(900),
+        )
+
+        check_step_function_running_function.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "states:*",
+                ],
+                resources=[
+                    "*",
+                ],
+            )
+        )
+
         CfnOutput(
             self,
             "WorkgroupNameOutput",
@@ -113,6 +136,12 @@ class DataBakerCoreStack(DataBakerStack):
             "EmptyS3BucketByPrefixArnOutput",
             value=empty_s3_bucket_by_prefix_lambda.function_arn,
             export_name="EmptyS3BucketByPrefixArnOutput",
+        )
+        CfnOutput(
+            self,
+            "CheckStepFunctionRunningArnOutput",
+            value=check_step_function_running_function.function_arn,
+            export_name="CheckStepFunctionRunningArnOutput",
         )
 
     def make_database(self):


### PR DESCRIPTION
State machines don't have a built-in concurrency limit. So, I've added a new Lambda function that uses boto3 to check for other executions of the same definition. 

This adds some complexity to the flow diagram code, but it makes sense to look at:

![image](https://github.com/user-attachments/assets/ca628e85-7ee5-4aec-b7dc-1447f207c890)

I've tested this manually by running two executions at the same time, in the console. 