### PR TITLE
Addressbase cleaned location info

### DIFF
--- a/cdk/queries/partition-addressbase-cleaned.sql
+++ b/cdk/queries/partition-addressbase-cleaned.sql
@@ -6,6 +6,7 @@ UNLOAD
        postcode,
        ST_X(ST_GeometryFromText(split_part(location, ';', 2))) AS longitude,
        ST_Y(ST_GeometryFromText(split_part(location, ';', 2))) AS latitude,
+       '{addressbase_source}' as addressbase_source,
        substr(postcode, 1, 1) AS first_letter
     FROM "$from_table"
 )

--- a/cdk/queries/uprn-to-ballots-first-letter.sql
+++ b/cdk/queries/uprn-to-ballots-first-letter.sql
@@ -2,6 +2,7 @@ UNLOAD (
 		SELECT combined_results.uprn,
 			combined_results.address,
 			combined_results.postcode,
+			combined_results.addressbase_source,
 			array_sort(filter(array_agg(DISTINCT combined_results.election_id), x -> x IS NOT NULL)) AS ballot_ids,
 			combined_results.first_letter AS first_letter
 		FROM (
@@ -9,6 +10,7 @@ UNLOAD (
 					ab.address,
 					ab.postcode,
 					ab.first_letter,
+					ab.addressbase_source,
 					cb.election_id
 				FROM addressbase_partitioned ab
 					LEFT JOIN current_ballots cb ON ST_CONTAINS(
@@ -22,6 +24,7 @@ UNLOAD (
 					ab.address,
 					ab.postcode,
 					ab.first_letter,
+					ab.addressbase_source,
 					cb.election_id
 				FROM addressbase_partitioned ab
 					LEFT JOIN current_ballots cb ON ST_CONTAINS(
@@ -34,6 +37,7 @@ UNLOAD (
 		GROUP BY combined_results.uprn,
 			combined_results.address,
 			combined_results.postcode,
+			combined_results.addressbase_source,
 			combined_results.first_letter
 	) TO 's3://dc-data-baker-results-bucket/current_ballots_joined_to_address_base/' WITH (
 		format = 'PARQUET',

--- a/cdk/shared_components/constructs/addressbase_source_check_construct.py
+++ b/cdk/shared_components/constructs/addressbase_source_check_construct.py
@@ -1,0 +1,91 @@
+from aws_cdk import (
+    aws_lambda as lambda_,
+)
+from aws_cdk import (
+    aws_stepfunctions as sfn,
+)
+from aws_cdk import (
+    aws_stepfunctions_tasks as tasks,
+)
+from constructs import Construct
+
+
+class AddressBaseSourceCheckConstruct(Construct):
+    """
+    A CDK construct that checks if there is exactly one distinct addressbase source.
+
+    This construct creates a three-step workflow:
+    1. Run an Athena query to count distinct addressbase sources
+    2. Get the query results
+    3. Check if there's exactly one source, succeeding if yes, fail if no.
+
+    Parameters:
+    -----------
+    scope : Construct
+        The parent construct
+    id : str
+        The construct ID
+    athena_query_lambda : lambda_.IFunction
+        The Lambda function that will execute Athena queries
+    table_name : str
+        The table name to check against. Must have a column named 'addressbase_source'
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        athena_query_lambda: lambda_.IFunction,
+        table_name,
+        **kwargs,
+    ):
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create the state to count distinct addressbase sources
+        count_distinct_addressbase_source = tasks.LambdaInvoke(
+            self,
+            "Count distinct addressbase sources",
+            lambda_function=athena_query_lambda,
+            payload=sfn.TaskInput.from_object(
+                {
+                    "context": {"table_name": table_name},
+                    "QueryString": "SELECT COUNT(DISTINCT addressbase_source) AS addressbase_sources_count FROM {table_name};",
+                    "blocking": True,
+                }
+            ),
+        )
+
+        # Create the state to get Athena query results
+        get_addressbase_source_count = tasks.AthenaGetQueryResults(
+            self,
+            "Get addressbase sources count",
+            query_execution_id="{% $states.input.Payload.queryExecutionId %}",
+            query_language=sfn.QueryLanguage.JSONATA,
+            assign={
+                "addressbase_source_count": "{% $states.result.ResultSet.Rows[1].Data[0].VarCharValue %}"
+            },
+        )
+
+        # Create the state to check if there's exactly one addressbase source
+        check_addressbase_source_count = (
+            sfn.Choice(self, "Check addressbase source count")
+            .when(
+                sfn.Condition.string_equals(
+                    "$addressbase_source_count",
+                    "1",
+                ),
+                sfn.Succeed(
+                    self,
+                    "Only one source of addresssbase!",
+                ),
+            )
+            .otherwise(sfn.Fail(self, "Not one source of addresssbase!"))
+        )
+
+        # Chain the states together
+        count_distinct_addressbase_source.next(
+            get_addressbase_source_count
+        ).next(check_addressbase_source_count)
+
+        # Expose the entry point as a property to connect to other state machines
+        self.entry_point = count_distinct_addressbase_source

--- a/cdk/shared_components/lambdas/get_glue_table_location/get_glue_table_location.py
+++ b/cdk/shared_components/lambdas/get_glue_table_location/get_glue_table_location.py
@@ -1,0 +1,22 @@
+import boto3
+
+
+def handler(event, context):
+    database = event["database"]
+    table = event["table"]
+
+    glue_client = boto3.client("glue")
+
+    response = glue_client.get_table(DatabaseName=database, Name=table)
+    location = response["Table"]["StorageDescriptor"]["Location"]
+
+    return {f"{table}_location": location}
+
+
+if __name__ == "__main__":
+    print(
+        handler(
+            {"database": "dc_data_baker", "table": "addressbase_cleaned_raw"},
+            {},
+        )
+    )

--- a/cdk/shared_components/lambdas/run_athena_query_and_report_status.py
+++ b/cdk/shared_components/lambdas/run_athena_query_and_report_status.py
@@ -76,7 +76,7 @@ def handler(event, context):
         response = get_named_query_by_name(saved_query_name)
         query_string = response["QueryString"]
 
-    # The query can contain $foo template strings that are replaced with
+    # The query can contain {foo} placeholder strings that are replaced with
     # items in event["context"]
     formatted_query = query_string.format(**event.get("context", {}))
 

--- a/cdk/shared_components/tables.py
+++ b/cdk/shared_components/tables.py
@@ -78,7 +78,10 @@ current_ballots_joined_to_address_base = GlueTable(
         "uprn": glue.Schema.STRING,
         "address": glue.Schema.STRING,
         "postcode": glue.Schema.STRING,
-        "ballot_ids": glue.Schema.array(input_string="string", is_primitive=True),
+        "addressbase_source": glue.Schema.STRING,
+        "ballot_ids": glue.Schema.array(
+            input_string="string", is_primitive=True
+        ),
         "first_letter": glue.Schema.STRING,
     },
     populated_with=BaseQuery(

--- a/cdk/shared_components/tables.py
+++ b/cdk/shared_components/tables.py
@@ -37,6 +37,7 @@ addressbase_partitioned = GlueTable(
         "postcode": glue.Schema.STRING,
         "longitude": glue.Schema.DOUBLE,
         "latitude": glue.Schema.DOUBLE,
+        "addressbase_source": glue.Schema.STRING,
     },
     partition_keys=[
         glue.Column(

--- a/cdk/stacks/addressbase.py
+++ b/cdk/stacks/addressbase.py
@@ -56,7 +56,7 @@ class AddressBaseStack(DataBakerStack):
             )
         )
         context = addressbase_partitioned.populated_with.context.copy()
-
+        addressbase_source = "addressbase_source"
         get_addressbase_cleaned_raw_glue_table_location = tasks.LambdaInvoke(
             self,
             "Get addressbase cleaned raw glue table location",
@@ -69,7 +69,7 @@ class AddressBaseStack(DataBakerStack):
             ),
             query_language=sfn.QueryLanguage.JSONATA,
             assign={
-                "addressbase_source": "{% $states.result.Payload.addressbase_cleaned_raw_location %}"
+                addressbase_source: "{% $states.result.Payload.addressbase_cleaned_raw_location %}"
             },
         )
         delete_old_objects = tasks.LambdaInvoke(
@@ -85,6 +85,7 @@ class AddressBaseStack(DataBakerStack):
                 }
             ),
         )
+        context[addressbase_source] = "{% $addressbase_source %}"
         partition = tasks.LambdaInvoke(
             self,
             "Partition AddressBase Cleaned",
@@ -96,6 +97,7 @@ class AddressBaseStack(DataBakerStack):
                     "blocking": True,
                 }
             ),
+            query_language=sfn.QueryLanguage.JSONATA,
         )
 
         make_partitions = tasks.LambdaInvoke(

--- a/cdk/stacks/data_baker_core.py
+++ b/cdk/stacks/data_baker_core.py
@@ -89,7 +89,6 @@ class DataBakerCoreStack(DataBakerStack):
             )
         )
 
-
         check_step_function_running_function = aws_lambda_python.PythonFunction(
             self,
             "check_step_function_running",
@@ -110,6 +109,21 @@ class DataBakerCoreStack(DataBakerStack):
                     "*",
                 ],
             )
+        )
+
+        get_glue_table_location_lambda = aws_lambda_python.PythonFunction(
+            self,
+            "get_glue_table_location",
+            function_name="get_glue_table_location",
+            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            handler="handler",
+            entry="cdk/shared_components/lambdas/get_glue_table_location",
+            index="get_glue_table_location.py",
+            timeout=Duration.seconds(300),
+        )
+
+        get_glue_table_location_lambda.add_to_role_policy(
+            iam.PolicyStatement(actions=["glue:GetTable"], resources=["*"]),
         )
 
         CfnOutput(
@@ -142,6 +156,12 @@ class DataBakerCoreStack(DataBakerStack):
             "CheckStepFunctionRunningArnOutput",
             value=check_step_function_running_function.function_arn,
             export_name="CheckStepFunctionRunningArnOutput",
+        )
+        CfnOutput(
+            self,
+            "GetGlueTableLocationArnOutput",
+            value=get_glue_table_location_lambda.function_arn,
+            export_name="GetGlueTableLocationArnOutput",
         )
 
     def make_database(self):


### PR DESCRIPTION
Still work in progress, but hopefully useful for following along. 

The aims are:
* capture where on s3 we read addressbase_cleaned_raw from in a step function variable.
* use the variable to write the s3 location into the parquet files that are derived from that addressbase

We're using this method (writing a column to the parquet files) because we can't write parquet metadata using the `unload` function of athena,  (and maybe not polars either). Given that parquet is column wise, having a column where all rows share the same value shouldn't add too much in terms of file sizes/read times. 