### PR TITLE
Fix string templating for partition query.

### DIFF
--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -15,7 +15,7 @@ def handler(event, context):
     dest_bucket_name = event["dest_bucket_name"]
     dest_path = event["dest_path"]
 
-    prefix = f"{source_path}/first_letter={first_letter}"
+    prefix = f"{source_path}first_letter={first_letter}"
 
     response = s3_client.list_objects_v2(
         Bucket=source_bucket_name, Prefix=prefix

--- a/cdk/stacks/addressbase.py
+++ b/cdk/stacks/addressbase.py
@@ -111,7 +111,7 @@ class AddressBaseStack(DataBakerStack):
                     "context": {
                         "table_name": addressbase_partitioned.table_name
                     },
-                    "QueryString": "MSCK REPAIR TABLE `$table_name`;",
+                    "QueryString": "MSCK REPAIR TABLE `{table_name}`;",
                     "blocking": True,
                 }
             ),

--- a/cdk/stacks/current_elections.py
+++ b/cdk/stacks/current_elections.py
@@ -195,7 +195,9 @@ class CurrentElectionsStack(DataBakerStack):
                         {
                             "first_letter": letter,
                             "source_bucket_name": current_ballots_joined_to_address_base.bucket.bucket_name,
-                            "source_path": current_ballots_joined_to_address_base.s3_prefix,
+                            "source_path": current_ballots_joined_to_address_base.s3_prefix.format(
+                                dc_environment=self.dc_environment
+                            ),
                             "dest_bucket_name": pollingstations_private_data.bucket_name,
                             "dest_path": f"addressbase/{self.dc_environment}/current_elections_parquet",
                         }


### PR DESCRIPTION
I think this didn't fail in production because the table it was pointed at had already had the partitions created. From what I can tell you don't _need_ to re-run this command after every unload. So in effect the query was a no-op. Why it didn't complain more loudly I'm unsure. 