### PR TITLE
Allow push to current elections queue

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        aws-actions/configure-aws-credentials: ref-pin
+        astral-sh/setup-uv: ref-pin

--- a/cdk/stacks/current_elections.py
+++ b/cdk/stacks/current_elections.py
@@ -208,6 +208,7 @@ class CurrentElectionsStack(DataBakerStack):
         )
 
         self.make_run_nightly_rule(event_queue)
+        self.make_rebuild_election_parquet_rule(event_queue)
         self.make_sqs_to_sfn_pipe(event_queue)
 
     def make_sqs_to_sfn_pipe(self, event_queue):
@@ -258,6 +259,21 @@ class CurrentElectionsStack(DataBakerStack):
                 message=aws_events.RuleTargetInput.from_text("Nightly re-run"),
                 message_group_id="elections_set_changed",
             )
+        )
+
+    def make_rebuild_election_parquet_rule(self, event_queue):
+        aws_events.Rule(
+            self,
+            "RebuildCurrentElectionsParquetTrigger",
+            targets=[
+                aws_events_targets.SqsQueue(
+                    event_queue,
+                    message_group_id="elections_set_changed",
+                ),
+            ],
+            event_pattern=aws_events.EventPattern(
+                detail_type=["elections_set_changed"]
+            ),
         )
 
     def make_delete_old_current_ballots_joined_to_addressbase_task(


### PR DESCRIPTION
All the default event buses have a resource policy which allows events from within the org. 

* So all this does is a refactor of the current elections stack (doesn't change anything, but makes the code added in the next commit a bit more manageable)
* Adds a rule that will match events sent with a detail type of `elections_set_changed`.
* Some chores to get CI to pass
