### PR TITLE
Order the boundary review objects

### DIFF
--- a/cdk/queries/current-boundary-reviews-to-addressbase.sql
+++ b/cdk/queries/current-boundary-reviews-to-addressbase.sql
@@ -17,7 +17,7 @@ UNLOAD (
 			uprn,
 			boundary_review_id,
             arbitrary(boundary_review_details) AS boundary_review_details,
-            array_agg(boundary_change_details) AS boundary_changes
+            array_agg(boundary_change_details ORDER BY division_type) AS boundary_changes
 		FROM addresses_to_boundary_change
 		GROUP BY uprn, boundary_review_id
 	),
@@ -29,6 +29,7 @@ UNLOAD (
                    '{{"boundary_review_id":' || json_format(CAST(boundary_review_id AS JSON)) ||
                    ',"boundary_review_details":' || json_format(CAST(boundary_review_details AS JSON)) ||
                    ',"changes":' || json_format(CAST(boundary_changes AS JSON)) || '}}'
+                    ORDER BY boundary_review_id
             ) AS boundary_reviews
 		FROM grouped_by_review
 		GROUP BY uprn

--- a/scripts/check-state-machines-run.py
+++ b/scripts/check-state-machines-run.py
@@ -34,7 +34,7 @@ class CheckStateMachinesRun:
             self.current_elections_state_machine_arn, timeout=120
         )
         self.check_state_machine(
-            self.current_boundary_changes_state_machine_arn, timeout=120
+            self.current_boundary_changes_state_machine_arn, timeout=240
         )
 
     def get_addressbase_state_machine_arn(self):


### PR DESCRIPTION
The order doesn't matter, but we do want the ordering to be the same for every address. This is becasue in the aggregator api we grab all the rows for a given postcode, and check whether the boundary review column is unique over those rose.

This does slow the query down a bit from ~1m50s to 2m30s. But this seems worth it to keep the sorting out of each request cycle on the devs api side. When we do this for multiple boundary reviews it might be something we have to revisit.


