### PR TITLE
Generic concurrency check

### DIFF
--- a/cdk/shared_components/constructs/guarded_step_function_construct.py
+++ b/cdk/shared_components/constructs/guarded_step_function_construct.py
@@ -1,0 +1,93 @@
+from aws_cdk import Duration, Fn, aws_lambda
+from aws_cdk import aws_stepfunctions as sfn
+from aws_cdk import aws_stepfunctions_tasks as tasks
+from constructs import Construct
+
+
+class GuardedStepFunctionConstruct(Construct):
+    """
+    A CDK construct that returns a step function with a built-in guard to prevent concurrent executions.
+    The step function will invoke a lambda function to check if there are any running executions of the same state machine, and only proceed if there are none.
+
+    Parameters:
+    -----------
+    scope : Construct
+        The parent construct
+    id : str
+        The construct ID
+    step_function_name : str
+        The name of the step function
+    main_tasks : sfn.IChainable
+        The main tasks of the step function
+    timeout_minutes : int
+        The timeout for the step function in minutes (default: 10)
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        step_function_name: str,
+        main_tasks: sfn.IChainable,
+        timeout_minutes: int = 10,
+        **kwargs,
+    ):
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.check_step_function_running = Fn.import_value(
+            "CheckStepFunctionRunningArnOutput"
+        )
+        self.check_step_function_running_function = (
+            aws_lambda.Function.from_function_arn(
+                self,
+                "CheckStepFunctionRunningArnOutput",
+                self.check_step_function_running,
+            )
+        )
+
+        should_run_decision = self.make_should_run_decision(main_tasks)
+
+        check_step_function_running_task = (
+            self.make_check_step_function_running_task()
+        )
+        state_definition = check_step_function_running_task.next(
+            should_run_decision
+        )
+
+        step_function = sfn.StateMachine(
+            self,
+            step_function_name,
+            state_machine_name=step_function_name,
+            definition=state_definition,
+            timeout=Duration.minutes(timeout_minutes),
+        )
+
+        self.entry_point = step_function
+
+    def make_check_step_function_running_task(self) -> tasks.LambdaInvoke:
+        return tasks.LambdaInvoke(
+            self,
+            "CheckConcurrentExecution",
+            lambda_function=self.check_step_function_running_function,
+            payload=sfn.TaskInput.from_object(
+                {
+                    "stateMachineArn.$": "$$.StateMachine.Id",
+                    "currentExecutionArn.$": "$$.Execution.Id",
+                }
+            ),
+            output_path="$.Payload",
+        )
+
+    def make_should_run_decision(self, main_tasks) -> sfn.Choice:
+        fail_state = sfn.Fail(
+            self,
+            "StopExecution",
+            cause="ConcurrentExecution",
+            error="AnotherExecutionRunning",
+        )
+        decision = sfn.Choice(self, "CanProceed?")
+        decision.when(
+            sfn.Condition.boolean_equals("$.proceed", True), main_tasks
+        )
+        decision.otherwise(fail_state)
+        return decision

--- a/cdk/shared_components/constructs/singleton_state_machine_construct.py
+++ b/cdk/shared_components/constructs/singleton_state_machine_construct.py
@@ -4,7 +4,7 @@ from aws_cdk import aws_stepfunctions_tasks as tasks
 from constructs import Construct
 
 
-class GuardedStepFunctionConstruct(Construct):
+class SingletonStateMachineConstruct(Construct):
     """
     A CDK construct that returns a step function with a built-in guard to prevent concurrent executions.
     The step function will invoke a lambda function to check if there are any running executions of the same state machine, and only proceed if there are none.

--- a/cdk/stacks/current_boundary_changes.py
+++ b/cdk/stacks/current_boundary_changes.py
@@ -21,6 +21,9 @@ from shared_components.buckets import (
 from shared_components.constructs.addressbase_data_quality_check_construct import (
     AddressbaseDataQualityCheckConstruct,
 )
+from shared_components.constructs.guarded_step_function_construct import (
+    GuardedStepFunctionConstruct,
+)
 from shared_components.constructs.make_partitions_construct import (
     MakePartitionsConstruct,
 )
@@ -53,16 +56,6 @@ class CurrentBoundaryChangesStack(DataBakerStack):
         self.empty_bucket_by_prefix_lambda = (
             aws_lambda.Function.from_function_arn(
                 self, "EmptyS3BucketByPrefix", self.empty_bucket_by_prefix
-            )
-        )
-        self.check_step_function_running = Fn.import_value(
-            "CheckStepFunctionRunningArnOutput"
-        )
-        self.check_step_function_running_function = (
-            aws_lambda.Function.from_function_arn(
-                self,
-                "CheckStepFunctionRunningArnOutput",
-                self.check_step_function_running,
             )
         )
 
@@ -136,13 +129,12 @@ class CurrentBoundaryChangesStack(DataBakerStack):
             .next(parallel_outcodes_task)
         )
 
-        self.step_function = sfn.StateMachine(
+        self.step_function = GuardedStepFunctionConstruct(
             self,
             "MakeCurrentBoundaryChangesParquet",
-            state_machine_name="MakeCurrentBoundaryChangesParquet",
-            definition=main_tasks,
-            timeout=Duration.minutes(10),
-        )
+            step_function_name="MakeCurrentBoundaryChangesParquet",
+            main_tasks=main_tasks,
+        ).entry_point
 
         self.make_event_triggers()
 

--- a/cdk/stacks/current_boundary_changes.py
+++ b/cdk/stacks/current_boundary_changes.py
@@ -21,11 +21,11 @@ from shared_components.buckets import (
 from shared_components.constructs.addressbase_data_quality_check_construct import (
     AddressbaseDataQualityCheckConstruct,
 )
-from shared_components.constructs.guarded_step_function_construct import (
-    GuardedStepFunctionConstruct,
-)
 from shared_components.constructs.make_partitions_construct import (
     MakePartitionsConstruct,
+)
+from shared_components.constructs.singleton_state_machine_construct import (
+    SingletonStateMachineConstruct,
 )
 from shared_components.constructs.step_function_event_queue_construct import (
     StepFunctionEventQueueConstruct,
@@ -129,7 +129,7 @@ class CurrentBoundaryChangesStack(DataBakerStack):
             .next(parallel_outcodes_task)
         )
 
-        self.step_function = GuardedStepFunctionConstruct(
+        self.step_function = SingletonStateMachineConstruct(
             self,
             "MakeCurrentBoundaryChangesParquet",
             step_function_name="MakeCurrentBoundaryChangesParquet",

--- a/cdk/stacks/current_elections.py
+++ b/cdk/stacks/current_elections.py
@@ -37,11 +37,11 @@ from shared_components.buckets import (
 from shared_components.constructs.addressbase_source_check_construct import (
     AddressBaseSourceCheckConstruct,
 )
-from shared_components.constructs.guarded_step_function_construct import (
-    GuardedStepFunctionConstruct,
-)
 from shared_components.constructs.make_partitions_construct import (
     MakePartitionsConstruct,
+)
+from shared_components.constructs.singleton_state_machine_construct import (
+    SingletonStateMachineConstruct,
 )
 from shared_components.constructs.step_function_event_queue_construct import (
     StepFunctionEventQueueConstruct,
@@ -116,7 +116,7 @@ class CurrentElectionsStack(DataBakerStack):
             .next(addressbase_check.entry_point)
         )
 
-        self.step_function = GuardedStepFunctionConstruct(
+        self.step_function = SingletonStateMachineConstruct(
             self,
             "MakeCurrentElectionsParquet ",
             step_function_name="MakeCurrentElectionsParquet",

--- a/cdk/stacks/current_elections.py
+++ b/cdk/stacks/current_elections.py
@@ -37,6 +37,9 @@ from shared_components.buckets import (
 from shared_components.constructs.addressbase_source_check_construct import (
     AddressBaseSourceCheckConstruct,
 )
+from shared_components.constructs.guarded_step_function_construct import (
+    GuardedStepFunctionConstruct,
+)
 from shared_components.constructs.make_partitions_construct import (
     MakePartitionsConstruct,
 )
@@ -66,16 +69,6 @@ class CurrentElectionsStack(DataBakerStack):
         self.empty_bucket_by_prefix_lambda = (
             aws_lambda.Function.from_function_arn(
                 self, "EmptyS3BucketByPrefix", self.empty_bucket_by_prefix
-            )
-        )
-        self.check_step_function_running = Fn.import_value(
-            "CheckStepFunctionRunningArnOutput"
-        )
-        self.check_step_function_running_function = (
-            aws_lambda.Function.from_function_arn(
-                self,
-                "CheckStepFunctionRunningArnOutput",
-                self.check_step_function_running,
             )
         )
 
@@ -123,21 +116,12 @@ class CurrentElectionsStack(DataBakerStack):
             .next(addressbase_check.entry_point)
         )
 
-        should_run_decision = self.make_should_run_decision(main_tasks)
-        check_step_function_running_task = (
-            self.make_check_step_function_running_task()
-        )
-        state_definition = check_step_function_running_task.next(
-            should_run_decision
-        )
-
-        self.step_function = sfn.StateMachine(
+        self.step_function = GuardedStepFunctionConstruct(
             self,
-            "MakeCurrentElectionsParquet",
-            state_machine_name="MakeCurrentElectionsParquet",
-            definition=state_definition,
-            timeout=Duration.minutes(10),
-        )
+            "MakeCurrentElectionsParquet ",
+            step_function_name="MakeCurrentElectionsParquet",
+            main_tasks=main_tasks,
+        ).entry_point
 
         self.make_event_triggers()
 
@@ -155,34 +139,6 @@ class CurrentElectionsStack(DataBakerStack):
     @staticmethod
     def s3_buckets() -> List[S3Bucket]:
         return [ee_data_cache_production, pollingstations_private_data]
-
-    def make_should_run_decision(self, main_tasks) -> sfn.Choice:
-        fail_state = sfn.Fail(
-            self,
-            "StopExecution",
-            cause="ConcurrentExecution",
-            error="AnotherExecutionRunning",
-        )
-        decision = sfn.Choice(self, "CanProceed?")
-        decision.when(
-            sfn.Condition.boolean_equals("$.proceed", True), main_tasks
-        )
-        decision.otherwise(fail_state)
-        return decision
-
-    def make_check_step_function_running_task(self) -> tasks.LambdaInvoke:
-        return tasks.LambdaInvoke(
-            self,
-            "CheckConcurrentExecution",
-            lambda_function=self.check_step_function_running_function,
-            payload=sfn.TaskInput.from_object(
-                {
-                    "stateMachineArn.$": "$$.StateMachine.Id",
-                    "currentExecutionArn.$": "$$.Execution.Id",
-                }
-            ),
-            output_path="$.Payload",
-        )
 
     def make_create_current_csv_task(self) -> tasks.LambdaInvoke:
         create_current_elections_csv_function = aws_lambda_python.PythonFunction(


### PR DESCRIPTION
This PR adds a construct that creates a step function with a concurrency check before the main tasks and makes both the current elections and current boundary changes layer use it. I went with `GuardedStepFunction` for the name but open to suggestions.


Tested by deploying to dev and triggering concurrent executions. 

#### Note on deployment:
Deploying to stage/prod will fail because the existing step functions have the same name as the step functions in the construct. The work around is to temporarily change the name of the step functions, deploy them, and then deploy this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212884969150110