### PR TITLE
Duplicate uprns

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -11,3 +11,7 @@ runs:
     - name: Pre-test checks
       shell: bash
       run: uv run scripts/code-check.sh
+
+    - name: Run tests
+      shell: bash
+      run: uv run --with polars --with sentry-sdk pytest

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -40,12 +40,19 @@ def check_duplicate_uprns(
     If duplicates have conflicting data, raise ConflictingDuplicateUPRNError.
 
     """
-    duplicated_uprn_count = first_letter_data.filter(
+    duplicated_rows = first_letter_data.filter(
         polars.col("uprn").is_duplicated()
-    )["uprn"].n_unique()
+    )
+    duplicated_uprn_count = duplicated_rows["uprn"].n_unique()
 
     if duplicated_uprn_count == 0:
         return first_letter_data
+
+    logger.warning(
+        f"check_duplicate_uprns: {first_letter=} {len(first_letter_data)=} {duplicated_uprn_count=}"
+    )
+    logger.warning(f"duplicated uprns:\n{duplicated_rows.sort('uprn')}")
+
     if duplicated_uprn_count == 1:
         msg = f"{duplicated_uprn_count} UPRN has duplicated rows for first_letter={first_letter}"
     else:

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -1,14 +1,115 @@
+import logging
 import os
 import shutil
+import urllib.parse
 from pathlib import Path
 
 import boto3
 import polars
+import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN"),
+    integrations=[AwsLambdaIntegration()],
+)
+
+
+class IdenticalDuplicateUPRNError(Exception):
+    pass
+
+
+class ConflictingDuplicateUPRNError(Exception):
+    pass
+
+
+logger = logging.getLogger(__name__)
 
 s3_client = boto3.client("s3")
 
 
+def check_duplicate_uprns(
+    first_letter_data: polars.DataFrame, first_letter: str
+) -> polars.DataFrame:
+    """
+    Check for duplicate UPRNs in the data.
+
+    If there are no duplicate UPRNs then return the data unchanged.
+    If all duplicates are identical rows, deduplicate, report to Sentry and return deduplicated dataframe.
+    If duplicates have conflicting data, raise ConflictingDuplicateUPRNError.
+
+    """
+    duplicated_uprn_count = first_letter_data.filter(
+        polars.col("uprn").is_duplicated()
+    )["uprn"].n_unique()
+
+    if duplicated_uprn_count == 0:
+        return first_letter_data
+    if duplicated_uprn_count == 1:
+        msg = f"{duplicated_uprn_count} UPRN has duplicated rows for first_letter={first_letter}"
+    else:
+        msg = f"{duplicated_uprn_count} UPRNs have duplicate rows for first_letter={first_letter}"
+    unique_rows = first_letter_data.unique()
+
+    if unique_rows["uprn"].n_unique() == len(unique_rows):
+        # All duplicate rows are identical, safe to deduplicate
+        msg += (
+            " All duplicates are identical. Deduplicating and continuing."
+            " The data is probably correct, but we want to understand why this happened."
+        )
+
+        logger.error(msg)
+        with sentry_sdk.new_scope() as scope:
+            scope.set_context(
+                "duplicate_uprns",
+                {
+                    "first_letter": first_letter,
+                    "duplicated_uprn_count": duplicated_uprn_count,
+                },
+            )
+            scope.capture_exception(IdenticalDuplicateUPRNError(msg))
+        return unique_rows
+
+    # Some duplicate UPRNs have conflicting data
+    with sentry_sdk.new_scope() as scope:
+        scope.set_context(
+            "duplicate_uprns",
+            {
+                "first_letter": first_letter,
+                "duplicated_uprn_count": duplicated_uprn_count,
+            },
+        )
+        msg += (
+            " Duplicate uprns are not in identical rows."
+            " This indicates a data integrity issue that needs investigation."
+        )
+        raise ConflictingDuplicateUPRNError(msg)
+
+
 def handler(event, context):
+    # Add CloudWatch log link to Sentry context
+    # https://docs.aws.amazon.com/lambda/latest/dg/python-context.html
+    region = os.environ.get("AWS_REGION", "eu-west-2")
+    log_group = getattr(context, "log_group_name", None)
+    log_stream = getattr(context, "log_stream_name", None)
+    if log_group and log_stream:
+        encoded_group = urllib.parse.quote(log_group, safe="")
+        encoded_stream = urllib.parse.quote(log_stream, safe="")
+        cloudwatch_url = (
+            f"https://{region}.console.aws.amazon.com/cloudwatch/home"
+            f"?region={region}#logsV2:log-groups/log-group/{encoded_group}"
+            f"/log-events/{encoded_stream}"
+        )
+        sentry_sdk.set_context(
+            "cloudwatch",
+            {
+                "url": cloudwatch_url,
+                "log_group": log_group,
+                "log_stream": log_stream,
+                "request_id": getattr(context, "aws_request_id", None),
+            },
+        )
+
     # Get parameters from the event.
     first_letter = event["first_letter"]
     source_bucket_name = event["source_bucket_name"]
@@ -52,6 +153,9 @@ def handler(event, context):
 
     print(f"{LOCAL_SOURCE_DIR}/*")
     first_letter_data = polars.read_parquet(f"{LOCAL_SOURCE_DIR}/*")
+
+    first_letter_data = check_duplicate_uprns(first_letter_data, first_letter)
+
     first_letter_data = first_letter_data.with_columns(
         polars.col("postcode").str.split(" ").list.first().alias("outcode")
     )

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -11,6 +11,7 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
+    environment=os.environ.get("DC_ENVIRONMENT"),
     integrations=[AwsLambdaIntegration()],
 )
 
@@ -202,9 +203,9 @@ def handler(event, context):
 
 if __name__ == "__main__":
     event = {
-        "first_letter": "G",
-        "source_bucket_name": "dc-data-baker-results-bucket",
-        "source_path": "current_ballots_joined_to_address_base/",
+        "first_letter": "A",
+        "source_bucket_name": "pollingstations.private.data",
+        "source_path": "addressbase/development/current_ballots_joined_to_address_base/",
         "dest_bucket_name": "dc-data-baker-results-bucket",
         "dest_path": "current_election_parquet",
         "filter_column": "ballot_ids",

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/requirements.txt
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/requirements.txt
@@ -1,1 +1,2 @@
 polars==1.22.0
+sentry-sdk==2.54.0

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
@@ -1,0 +1,226 @@
+from unittest.mock import patch
+
+import polars
+import pytest
+from first_letter_to_outcode_parquet import (
+    ConflictingDuplicateUPRNError,
+    IdenticalDuplicateUPRNError,
+    check_duplicate_uprns,
+)
+
+
+def make_df(rows):
+    return polars.DataFrame(
+        rows,
+        schema={
+            "uprn": polars.Utf8,
+            "postcode": polars.Utf8,
+            "addressbase_source": polars.Utf8,
+        },
+    )
+
+
+class TestCheckDuplicateUPRNs:
+    def test_missing_uprn_column_raises(self):
+        df = polars.DataFrame(
+            [
+                {
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                }
+            ],
+            schema={
+                "postcode": polars.Utf8,
+                "addressbase_source": polars.Utf8,
+            },
+        )
+        with pytest.raises(polars.exceptions.ColumnNotFoundError):
+            check_duplicate_uprns(df, "A")
+
+    def test_no_duplicates_returns_unchanged(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+            ]
+        )
+        result = check_duplicate_uprns(df, "A")
+        assert result.equals(df)
+
+    def test_identical_duplicates_are_deduplicated(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+            ]
+        )
+        result = check_duplicate_uprns(df, "A")
+        assert result["uprn"].to_list() == ["1", "2"]
+        assert len(result) == 2
+
+    @patch("first_letter_to_outcode_parquet.sentry_sdk")
+    def test_identical_duplicates_report_to_sentry(self, mock_sentry):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+            ]
+        )
+        check_duplicate_uprns(df, "A")
+
+        mock_sentry.new_scope.assert_called_once()
+        scope = mock_sentry.new_scope().__enter__()
+        scope.capture_exception.assert_called()
+        exc = scope.capture_exception.call_args[0][0]
+        assert isinstance(exc, IdenticalDuplicateUPRNError)
+
+    def test_conflicting_duplicates_raise(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v2/addressbase_cleaned",
+                },
+            ]
+        )
+        with pytest.raises(
+            ConflictingDuplicateUPRNError,
+            match="1 UPRN has duplicated rows for first_letter=A Duplicate uprns are not in identical rows. This indicates a data integrity issue that needs investigation.",
+        ):
+            check_duplicate_uprns(df, "A")
+
+    def test_conflicting_duplicates_message_includes_first_letter(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v2/addressbase_cleaned",
+                },
+            ]
+        )
+        with pytest.raises(
+            ConflictingDuplicateUPRNError, match="first_letter=A"
+        ):
+            check_duplicate_uprns(df, "A")
+
+    def test_mix_of_identical_and_conflicting_raises(self):
+        """If even one UPRN has conflicting data, it should raise."""
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v2/addressbase_cleaned",
+                },
+            ]
+        )
+        with pytest.raises(ConflictingDuplicateUPRNError):
+            check_duplicate_uprns(df, "A")
+
+    def test_empty_dataframe(self):
+        df = make_df([])
+        result = check_duplicate_uprns(df, "A")
+        assert len(result) == 0
+
+    def test_single_row(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                }
+            ]
+        )
+        result = check_duplicate_uprns(df, "A")
+        assert result.equals(df)
+
+    def test_multiple_uprns_all_with_identical_duplicates(self):
+        df = make_df(
+            [
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "1",
+                    "postcode": "AA1 1AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "2",
+                    "postcode": "AA1 1BB",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+                {
+                    "uprn": "3",
+                    "postcode": "SW1A 3AA",
+                    "addressbase_source": "s3://path/to/v1/addressbase_cleaned",
+                },
+            ]
+        )
+        result = check_duplicate_uprns(df, "A")
+        assert result["uprn"].n_unique() == 3
+        assert len(result) == 3

--- a/cdk/stacks/data_baker_core.py
+++ b/cdk/stacks/data_baker_core.py
@@ -143,6 +143,7 @@ class DataBakerCoreStack(DataBakerStack):
                 "SENTRY_DSN": ssm.StringParameter.value_for_string_parameter(
                     self, "/dc-data-baker/SENTRY_DSN"
                 ),
+                "DC_ENVIRONMENT": self.dc_environment,
             },
         )
 

--- a/cdk/stacks/data_baker_core.py
+++ b/cdk/stacks/data_baker_core.py
@@ -15,6 +15,9 @@ from aws_cdk import aws_athena as athena
 from aws_cdk import (
     aws_iam as iam,
 )
+from aws_cdk import (
+    aws_ssm as ssm,
+)
 from constructs import Construct
 from shared_components.buckets import (
     data_baker_results_bucket,
@@ -136,6 +139,11 @@ class DataBakerCoreStack(DataBakerStack):
             index="first_letter_to_outcode_parquet.py",
             timeout=Duration.seconds(900),
             memory_size=4096,
+            environment={
+                "SENTRY_DSN": ssm.StringParameter.value_for_string_parameter(
+                    self, "/dc-data-baker/SENTRY_DSN"
+                ),
+            },
         )
 
         first_letter_to_outcode_parquet_lambda.add_to_role_policy(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pre-commit==4.1.0",
+    "pytest==9.0.2",
     "ruff==0.9.5",
     "yamllint>=1.37.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -235,6 +235,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "constructs"
 version = "10.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -267,6 +276,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "yamllint" },
 ]
@@ -287,6 +297,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.1.0" },
+    { name = "pytest", specifier = "==9.0.2" },
     { name = "ruff", specifier = "==0.9.5" },
     { name = "yamllint", specifier = ">=1.37.0" },
 ]
@@ -337,6 +348,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -373,6 +393,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -388,6 +417,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -413,6 +451,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/8e/8c9fe7e32fdf9c386f83d59610cc819a25dadb874b5920f2d0ef7d35f46d/publication-0.0.3.tar.gz", hash = "sha256:68416a0de76dddcdd2930d1c8ef853a743cc96c82416c4e4d3b5d901c6276dc4", size = 5484, upload-time = "2019-01-15T07:52:23.914Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/d3/6308debad7afcdb3ea5f50b4b3d852f41eb566a311fbcb4da23755a28155/publication-0.0.3-py2.py3-none-any.whl", hash = "sha256:0248885351febc11d8a1098d5c8e3ab2dabcf3e8c0c96db1e17ecd12b53afbe6", size = 7687, upload-time = "2019-01-15T07:52:22.151Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I've created a [sentry project](https://democracy-club-gp.sentry.io/insights/projects/dc-data-baker), and sent some errors from my local machine.  Need to set `/dc-data-baker/SENTRY_DSN` in parameter store. Could share the aggregator api sentry project, so that it's one2one mapping of aws account <-> sentry project. But I don't really see why - unless there's a cost saving I'm unaware of. 


