### PR TITLE
ignore ordering under test

### DIFF
--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
@@ -76,7 +76,7 @@ class TestCheckDuplicateUPRNs:
             ]
         )
         result = check_duplicate_uprns(df, "A")
-        assert result["uprn"].to_list() == ["1", "2"]
+        assert sorted(result["uprn"].to_list()) == ["1", "2"]
         assert len(result) == 2
 
     @patch("first_letter_to_outcode_parquet.sentry_sdk")


### PR DESCRIPTION
When I pushed https://github.com/DemocracyClub/dc-data-baker/pull/45 my build failed
I think the order doesn't actually matter here, so we can just ignore order in the test.