### PR TITLE
Clean up files on parquet lambda

### DIFF
--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import boto3
 import polars
 import sentry_sdk
+from polars import DataFrame
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(
@@ -137,18 +138,126 @@ def handler(event, context):
         print(f"No objects found in s3://{source_bucket_name}/{prefix}")
         return
 
-    # Loop through each object and download it to /tmp.
+    local_source_dir = make_local_source_dir(filter_column, first_letter)
+    by_outcode_dir = make_outcode_dir(filter_column, first_letter)
+
+    download_parquet(response, local_source_dir, source_bucket_name)
+
+    outcode_dfs = get_outcode_dfs(first_letter, local_source_dir)
+
+    for outcode_df in outcode_dfs:
+        upload_outcode_parquet(
+            by_outcode_dir,
+            dest_bucket_name,
+            dest_path,
+            filter_column,
+            outcode_df,
+        )
+
+
+def make_outcode_dir(filter_column, first_letter) -> Path:
+    by_outcode_dir = Path(f"/tmp/by_outcodes/{filter_column}/{first_letter}")
+    if by_outcode_dir.exists():
+        shutil.rmtree(by_outcode_dir)
+    by_outcode_dir.mkdir(exist_ok=True, parents=True)
+    print(f"By outcode_path: {by_outcode_dir}")
+    return by_outcode_dir
+
+
+def make_local_source_dir(filter_column, first_letter) -> Path:
     local_source_dir = Path(f"/tmp/{filter_column}/{first_letter}")
     if local_source_dir.exists():
         shutil.rmtree(local_source_dir)
 
     local_source_dir.mkdir(exist_ok=True, parents=True)
+    print(f"Local source_dir: {local_source_dir}")
+    return local_source_dir
 
-    by_outcode_path = Path(f"/tmp/by_outcodes/{filter_column}/{first_letter}")
-    if by_outcode_path.exists():
-        shutil.rmtree(by_outcode_path)
-    by_outcode_path.mkdir(exist_ok=True, parents=True)
 
+def get_outcode_dfs(first_letter, local_source_dir: Path) -> list[DataFrame]:
+    """
+    Reads all the parquet files for postcodes starting with 'first_letter' into
+    a dataframe. Then adds an 'outcode' column, and then partitions the dataframe
+    into a dataframe per outcode.
+    These 'outcode dataframes' are returned as a list.
+
+    Args:
+        first_letter: The first letter of the postcode.
+        local_source_dir: Where the parquet files are stored locally
+
+    Returns: list of outcode dataframes
+
+    """
+    first_letter_data = polars.read_parquet(f"{local_source_dir}/*")
+
+    first_letter_data = check_duplicate_uprns(first_letter_data, first_letter)
+
+    first_letter_data = first_letter_data.with_columns(
+        polars.col("postcode").str.split(" ").list.first().alias("outcode")
+    )
+
+    return first_letter_data.partition_by("outcode")
+
+
+def upload_outcode_parquet(
+    by_outcode_dir: Path,
+    dest_bucket_name: str,
+    dest_path: str,
+    filter_column: str,
+    outcode_df: DataFrame,
+):
+    """
+    Checks outcode dataframe for any null values in filter_column,
+    and either writes outcode file with data, or an empty file if
+    all values are null. Then uploads the file to s3.
+
+    Args:
+        by_outcode_dir: Local directory for writing <outcode>.parquet files
+        dest_bucket_name: Bucket to upload <outcode>.parquet files to
+        dest_path: s3 prefix after bucket before file: s3://<dest_bucket_name>/<dest_path>/<outcode>.parquet
+        filter_column: column to check if it has non null values. Included here for print logs
+        outcode_df: dataframe with all outcode data.
+    """
+    outcode = outcode_df["outcode"][0]
+    print(outcode)
+
+    expr_has_non_null_filter_column = (
+        polars.col(filter_column)
+        .list.eval(polars.element().is_not_null())
+        .list.sum()
+        .alias(f"has_non_null_{filter_column}")
+    )
+
+    has_any_non_null_filter_column_df = outcode_df.select(
+        (expr_has_non_null_filter_column > 0)
+        .any()
+        .alias(f"any_row_has_{filter_column}")
+    )
+    has_any_non_null_filter_column = has_any_non_null_filter_column_df[
+        f"any_row_has_{filter_column}"
+    ][0]  # Boolean True/False
+
+    outcode_path = by_outcode_dir / f"{outcode}.parquet"
+
+    if has_any_non_null_filter_column:
+        print(
+            f"At least one UPRN in {outcode} has data in {filter_column}, writing a file with data"
+        )
+        outcode_df.sort(by=["postcode", "uprn"])
+        outcode_df.write_parquet(outcode_path)
+    else:
+        print(
+            f"No {filter_column} for any address in {outcode}, writing an empty file"
+        )
+        polars.DataFrame().write_parquet(outcode_path)
+    s3_client.upload_file(
+        outcode_path, dest_bucket_name, f"{dest_path}/{outcode}.parquet"
+    )
+
+
+def download_parquet(
+    response: dict, local_source_dir: Path, source_bucket_name: str
+):
     for obj in response["Contents"]:
         key = obj["Key"]
         # Use the basename of the key as the local filename.
@@ -158,54 +267,6 @@ def handler(event, context):
                 f"Downloading s3://{source_bucket_name}/{key} to {local_file}"
             )
             s3_client.download_file(source_bucket_name, key, local_file)
-
-    print(f"{local_source_dir}/*")
-    first_letter_data = polars.read_parquet(f"{local_source_dir}/*")
-
-    first_letter_data = check_duplicate_uprns(first_letter_data, first_letter)
-
-    first_letter_data = first_letter_data.with_columns(
-        polars.col("postcode").str.split(" ").list.first().alias("outcode")
-    )
-
-    outcode_dfs = first_letter_data.partition_by("outcode")
-
-    expr_has_non_null_filter_column = (
-        polars.col(filter_column)
-        .list.eval(polars.element().is_not_null())
-        .list.sum()
-        .alias(f"has_non_null_{filter_column}")
-    )
-
-    for outcode_df in outcode_dfs:
-        outcode = outcode_df["outcode"][0]
-        print(outcode)
-
-        has_any_non_null_filter_column_df = outcode_df.select(
-            (expr_has_non_null_filter_column > 0)
-            .any()
-            .alias(f"any_row_has_{filter_column}")
-        )
-        has_any_non_null_filter_column = has_any_non_null_filter_column_df[
-            f"any_row_has_{filter_column}"
-        ][0]  # Boolean True/False
-
-        outcode_path = by_outcode_path / f"{outcode}.parquet"
-
-        if has_any_non_null_filter_column:
-            print(
-                f"At least one UPRN in {outcode} has data in {filter_column}, writing a file with data"
-            )
-            outcode_df.sort(by=["postcode", "uprn"])
-            outcode_df.write_parquet(outcode_path)
-        else:
-            print(
-                f"No {filter_column} for any address in {outcode}, writing an empty file"
-            )
-            polars.DataFrame().write_parquet(outcode_path)
-        s3_client.upload_file(
-            outcode_path, dest_bucket_name, f"{dest_path}/{outcode}.parquet"
-        )
 
 
 if __name__ == "__main__":

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -138,29 +138,29 @@ def handler(event, context):
         return
 
     # Loop through each object and download it to /tmp.
-    LOCAL_SOURCE_DIR = Path(f"/tmp/{filter_column}/{first_letter}")
-    if LOCAL_SOURCE_DIR.exists():
-        shutil.rmtree(LOCAL_SOURCE_DIR)
+    local_source_dir = Path(f"/tmp/{filter_column}/{first_letter}")
+    if local_source_dir.exists():
+        shutil.rmtree(local_source_dir)
 
-    LOCAL_SOURCE_DIR.mkdir(exist_ok=True, parents=True)
+    local_source_dir.mkdir(exist_ok=True, parents=True)
 
-    BY_OUTCODE_PATH = Path(f"/tmp/by_outcodes/{filter_column}/{first_letter}")
-    if BY_OUTCODE_PATH.exists():
-        shutil.rmtree(BY_OUTCODE_PATH)
-    BY_OUTCODE_PATH.mkdir(exist_ok=True, parents=True)
+    by_outcode_path = Path(f"/tmp/by_outcodes/{filter_column}/{first_letter}")
+    if by_outcode_path.exists():
+        shutil.rmtree(by_outcode_path)
+    by_outcode_path.mkdir(exist_ok=True, parents=True)
 
     for obj in response["Contents"]:
         key = obj["Key"]
         # Use the basename of the key as the local filename.
-        local_file = LOCAL_SOURCE_DIR / os.path.basename(key)
+        local_file = local_source_dir / os.path.basename(key)
         if not local_file.exists():
             print(
                 f"Downloading s3://{source_bucket_name}/{key} to {local_file}"
             )
             s3_client.download_file(source_bucket_name, key, local_file)
 
-    print(f"{LOCAL_SOURCE_DIR}/*")
-    first_letter_data = polars.read_parquet(f"{LOCAL_SOURCE_DIR}/*")
+    print(f"{local_source_dir}/*")
+    first_letter_data = polars.read_parquet(f"{local_source_dir}/*")
 
     first_letter_data = check_duplicate_uprns(first_letter_data, first_letter)
 
@@ -190,7 +190,7 @@ def handler(event, context):
             f"any_row_has_{filter_column}"
         ][0]  # Boolean True/False
 
-        outcode_path = BY_OUTCODE_PATH / f"{outcode}.parquet"
+        outcode_path = by_outcode_path / f"{outcode}.parquet"
 
         if has_any_non_null_filter_column:
             print(

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -129,11 +129,9 @@ def handler(event, context):
 
     prefix = f"{source_path}first_letter={first_letter}"
 
-    response = s3_client.list_objects_v2(
-        Bucket=source_bucket_name, Prefix=prefix
-    )
+    object_keys = get_all_object_keys(source_bucket_name, prefix)
     # Check if there are any objects returned.
-    if "Contents" not in response:
+    if not object_keys:
         print(f"No objects found in s3://{source_bucket_name}/{prefix}")
         return
 
@@ -143,7 +141,7 @@ def handler(event, context):
     try:
         local_source_dir = make_local_source_dir(filter_column, first_letter)
         by_outcode_dir = make_outcode_dir(filter_column, first_letter)
-        download_parquet(response, local_source_dir, source_bucket_name)
+        download_parquet(object_keys, local_source_dir, source_bucket_name)
 
         outcode_dfs = get_outcode_dfs(first_letter, local_source_dir)
 
@@ -162,6 +160,22 @@ def handler(event, context):
 
         if by_outcode_dir:
             shutil.rmtree(by_outcode_dir)
+
+
+def get_all_object_keys(bucket_name: str, prefix: str) -> list[str]:
+    """
+    Args:
+        bucket_name: Bucket to list objects from
+        prefix: Only list objects whose keys start with this prefix
+
+    Returns: list of object keys
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    object_keys = []
+    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            object_keys.append(obj["Key"])
+    return object_keys
 
 
 def make_outcode_dir(filter_column, first_letter) -> Path:
@@ -263,10 +277,9 @@ def upload_outcode_parquet(
 
 
 def download_parquet(
-    response: dict, local_source_dir: Path, source_bucket_name: str
+    object_keys: list[str], local_source_dir: Path, source_bucket_name: str
 ):
-    for obj in response["Contents"]:
-        key = obj["Key"]
+    for key in object_keys:
         # Use the basename of the key as the local filename.
         local_file = local_source_dir / os.path.basename(key)
 

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -132,27 +132,36 @@ def handler(event, context):
     response = s3_client.list_objects_v2(
         Bucket=source_bucket_name, Prefix=prefix
     )
-
     # Check if there are any objects returned.
     if "Contents" not in response:
         print(f"No objects found in s3://{source_bucket_name}/{prefix}")
         return
 
-    local_source_dir = make_local_source_dir(filter_column, first_letter)
-    by_outcode_dir = make_outcode_dir(filter_column, first_letter)
+    local_source_dir = None
+    by_outcode_dir = None
 
-    download_parquet(response, local_source_dir, source_bucket_name)
+    try:
+        local_source_dir = make_local_source_dir(filter_column, first_letter)
+        by_outcode_dir = make_outcode_dir(filter_column, first_letter)
+        download_parquet(response, local_source_dir, source_bucket_name)
 
-    outcode_dfs = get_outcode_dfs(first_letter, local_source_dir)
+        outcode_dfs = get_outcode_dfs(first_letter, local_source_dir)
 
-    for outcode_df in outcode_dfs:
-        upload_outcode_parquet(
-            by_outcode_dir,
-            dest_bucket_name,
-            dest_path,
-            filter_column,
-            outcode_df,
-        )
+        for outcode_df in outcode_dfs:
+            upload_outcode_parquet(
+                by_outcode_dir,
+                dest_bucket_name,
+                dest_path,
+                filter_column,
+                outcode_df,
+            )
+
+    finally:
+        if local_source_dir:
+            shutil.rmtree(local_source_dir)
+
+        if by_outcode_dir:
+            shutil.rmtree(by_outcode_dir)
 
 
 def make_outcode_dir(filter_column, first_letter) -> Path:
@@ -168,7 +177,6 @@ def make_local_source_dir(filter_column, first_letter) -> Path:
     local_source_dir = Path(f"/tmp/{filter_column}/{first_letter}")
     if local_source_dir.exists():
         shutil.rmtree(local_source_dir)
-
     local_source_dir.mkdir(exist_ok=True, parents=True)
     print(f"Local source_dir: {local_source_dir}")
     return local_source_dir
@@ -262,11 +270,9 @@ def download_parquet(
         key = obj["Key"]
         # Use the basename of the key as the local filename.
         local_file = local_source_dir / os.path.basename(key)
-        if not local_file.exists():
-            print(
-                f"Downloading s3://{source_bucket_name}/{key} to {local_file}"
-            )
-            s3_client.download_file(source_bucket_name, key, local_file)
+
+        print(f"Downloading s3://{source_bucket_name}/{key} to {local_file}")
+        s3_client.download_file(source_bucket_name, key, local_file)
 
 
 if __name__ == "__main__":

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -139,8 +139,12 @@ def handler(event, context):
     by_outcode_dir = None
 
     try:
-        local_source_dir = make_local_source_dir(filter_column, first_letter)
-        by_outcode_dir = make_outcode_dir(filter_column, first_letter)
+        local_source_dir = clean_and_make_dir(
+            f"/tmp/{filter_column}/{first_letter}"
+        )
+        by_outcode_dir = clean_and_make_dir(
+            f"/tmp/by_outcodes/{filter_column}/{first_letter}"
+        )
         download_parquet(object_keys, local_source_dir, source_bucket_name)
 
         outcode_dfs = get_outcode_dfs(first_letter, local_source_dir)
@@ -178,22 +182,13 @@ def get_all_object_keys(bucket_name: str, prefix: str) -> list[str]:
     return object_keys
 
 
-def make_outcode_dir(filter_column, first_letter) -> Path:
-    by_outcode_dir = Path(f"/tmp/by_outcodes/{filter_column}/{first_letter}")
-    if by_outcode_dir.exists():
-        shutil.rmtree(by_outcode_dir)
-    by_outcode_dir.mkdir(exist_ok=True, parents=True)
-    print(f"By outcode_path: {by_outcode_dir}")
-    return by_outcode_dir
-
-
-def make_local_source_dir(filter_column, first_letter) -> Path:
-    local_source_dir = Path(f"/tmp/{filter_column}/{first_letter}")
-    if local_source_dir.exists():
-        shutil.rmtree(local_source_dir)
-    local_source_dir.mkdir(exist_ok=True, parents=True)
-    print(f"Local source_dir: {local_source_dir}")
-    return local_source_dir
+def clean_and_make_dir(path: str) -> Path:
+    dir_path = Path(path)
+    if dir_path.exists():
+        shutil.rmtree(dir_path)
+    dir_path.mkdir(parents=True)
+    print(f"Made {dir_path}")
+    return dir_path
 
 
 def get_outcode_dfs(first_letter, local_source_dir: Path) -> list[DataFrame]:

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py
@@ -251,8 +251,7 @@ def upload_outcode_parquet(
         print(
             f"At least one UPRN in {outcode} has data in {filter_column}, writing a file with data"
         )
-        outcode_df.sort(by=["postcode", "uprn"])
-        outcode_df.write_parquet(outcode_path)
+        outcode_df.sort(by=["postcode", "uprn"]).write_parquet(outcode_path)
     else:
         print(
             f"No {filter_column} for any address in {outcode}, writing an empty file"

--- a/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
+++ b/cdk/shared_components/lambdas/first_letter_to_outcode_parquet/test_first_letter_to_outcode_parquet.py
@@ -6,6 +6,7 @@ from first_letter_to_outcode_parquet import (
     ConflictingDuplicateUPRNError,
     IdenticalDuplicateUPRNError,
     check_duplicate_uprns,
+    upload_outcode_parquet,
 )
 
 
@@ -224,3 +225,51 @@ class TestCheckDuplicateUPRNs:
         result = check_duplicate_uprns(df, "A")
         assert result["uprn"].n_unique() == 3
         assert len(result) == 3
+
+
+class TestUploadOutcodeParquet:
+    def test_writes_sorted_data(self, tmp_path):
+        """The parquet file written for an outcode is sorted by postcode, uprn."""
+        outcode_df = polars.DataFrame(
+            {
+                "uprn": ["4", "3", "1", "2"],
+                "postcode": ["AA1 1BB", "AA1 1BB", "AA1 1AA", "AA1 1AA"],
+                "outcode": ["AA1", "AA1", "AA1", "AA1"],
+                "ballot_ids": [[], ["b1"], ["b2"], ["b3"]],
+            }
+        )
+
+        with patch("first_letter_to_outcode_parquet.s3_client"):
+            upload_outcode_parquet(
+                tmp_path, "dest-bucket", "dest/path", "ballot_ids", outcode_df
+            )
+
+        written = polars.read_parquet(tmp_path / "AA1.parquet")
+        assert written["postcode"].to_list() == [
+            "AA1 1AA",
+            "AA1 1AA",
+            "AA1 1BB",
+            "AA1 1BB",
+        ]
+        assert written["uprn"].to_list() == ["1", "2", "3", "4"]
+
+        assert written.equals(
+            polars.DataFrame(
+                {
+                    "uprn": ["1", "2", "3", "4"],
+                    "postcode": [
+                        "AA1 1AA",
+                        "AA1 1AA",
+                        "AA1 1BB",
+                        "AA1 1BB",
+                    ],
+                    "outcode": ["AA1", "AA1", "AA1", "AA1"],
+                    "ballot_ids": [
+                        ["b2"],
+                        ["b3"],
+                        ["b1"],
+                        [],
+                    ],
+                }
+            )
+        )


### PR DESCRIPTION
This PR is focussed on `cdk/shared_components/lambdas/first_letter_to_outcode_parquet/first_letter_to_outcode_parquet.py`. 

This had more or less been a 100+ line handler function. 
I've split this up into a bunch of smaller functions to make it a bit easier to parse. This also means that it is a bit easier to read when the bulk of it is wrapped in a `try`/`finally` block. 

I also spotted a bug about how the dataframe as (failing to be) sorted. 

I asked claude to review the work and it pointed out that `list_objects_v2` paginates once there are more than 1000 keys returned. I don't think we should ever hit this, but it does protect us against writing 'first letter parquet' files in such a way that we do create more than 1000 objects sometime in the future. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214931298744842